### PR TITLE
Set enclosing function when a program is met

### DIFF
--- a/src/astutil.js
+++ b/src/astutil.js
@@ -84,12 +84,6 @@ function init(root) {
 
         if (nd.type === 'Program') {
             enclosingFile = nd.attr.filename;
-            nd.type = 'FunctionDeclaration';
-            nd.id = {
-                    "type": "Identifier",
-                    "name": "global"
-                };
-            nd.params = [];
         }
 
         if (nd.type === 'FunctionDeclaration' ||
@@ -157,7 +151,6 @@ function funcname(func) {
 // encFunc can be undefined
 function encFuncName(encFunc) {
     if (encFunc === undefined) {
-        console.log("WARNING encFunc should NOT be undefined")
         return "global";
     } else if (encFunc.id === null)
         return "anon";

--- a/src/astutil.js
+++ b/src/astutil.js
@@ -84,11 +84,12 @@ function init(root) {
 
         if (nd.type === 'Program') {
             enclosingFile = nd.attr.filename;
-            enclosingFunction = nd
+            nd.type = 'FunctionDeclaration';
             nd.id = {
                     "type": "Identifier",
                     "name": "global"
                 };
+            nd.params = [];
         }
 
         if (nd.type === 'FunctionDeclaration' ||

--- a/src/astutil.js
+++ b/src/astutil.js
@@ -82,8 +82,14 @@ function init(root) {
         if (enclosingFile)
             nd.attr.enclosingFile = enclosingFile;
 
-        if (nd.type === 'Program')
+        if (nd.type === 'Program') {
             enclosingFile = nd.attr.filename;
+            enclosingFunction = nd
+            nd.id = {
+                    "type": "Identifier",
+                    "name": "global"
+                };
+        }
 
         if (nd.type === 'FunctionDeclaration' ||
             nd.type === 'FunctionExpression'  ||

--- a/src/astutil.js
+++ b/src/astutil.js
@@ -303,6 +303,16 @@ function getFunctions(root) {
             'encFuncName': encFuncName(fn.attr.enclosingFunction)
         });
     }
+    for (let i = 0; i < root.programs.length; i++) {
+      let prog = root.programs[i];
+      funcs.push({
+        'name': 'global',
+        'file': prog.attr.filename,
+        'range': prog.range,
+        'code': null,
+        'encFuncName': null
+      });
+    }
     funcs.forEach(funcObj => {
         funcObj['cf'] = cf(funcObj);
     });

--- a/src/astutil.js
+++ b/src/astutil.js
@@ -156,9 +156,10 @@ function funcname(func) {
 
 // encFunc can be undefined
 function encFuncName(encFunc) {
-    if (encFunc === undefined)
+    if (encFunc === undefined) {
+        console.log("WARNING encFunc should NOT be undefined")
         return "global";
-    else if (encFunc.id === null)
+    } else if (encFunc.id === null)
         return "anon";
     else
         return encFunc.id.name


### PR DESCRIPTION
When initializing the ast, ordinarily the enclosing function is set to be undefined if it is a global variable; however, with this change it will be set to be a function called global which will be the program node.