### PR TITLE
Remove slicing of argument

### DIFF
--- a/src/import.js
+++ b/src/import.js
@@ -221,10 +221,7 @@ function getRequiredFile(curr_filename, nd) {
     if (argument === undefined) {
         return
     }
-    // Question and potential TODO
-    // What would happen if argument is not "./define-module"?
-    let required_file = argument.slice(2);
-    required_file = path.resolve(curr_filename, '..', required_file);
+    required_file = path.resolve(curr_filename, '..', argument);
     return required_file + '.js';
 }
 


### PR DESCRIPTION
Because of the way path resolution works a path followed by `./` is the same as not having `./` at all so removing it from the string is unnecessary.